### PR TITLE
Fix typo in Basket_Remove2

### DIFF
--- a/assignment1/A1_Minitester.java
+++ b/assignment1/A1_Minitester.java
@@ -689,7 +689,7 @@ class Basket_Remove2 implements Runnable {
         int difference = originalNumberOfProducts - numberOfProducts;
         if(!a || !b){
 
-            throw new AssertionError("Expected: " + "a=true & b=false"
+            throw new AssertionError("Expected: " + "a=true & b=true"
                     + " but obtained: " + "a=" + a + " & b=" + b);
             //test if there are nulls in the array
         } else if (numberOfProducts < (myBasket.getProducts().length)){


### PR DESCRIPTION
The test expects both a and b to be true, but if the user fails the test it says it was expecting a=true and b=false